### PR TITLE
deprecatedなlist_familiesをfamiliesに変更

### DIFF
--- a/mikutter-mac-de-emoji.rb
+++ b/mikutter-mac-de-emoji.rb
@@ -30,7 +30,7 @@ Plugin.create(:mikutter_mac_de_emoji) {
   # フォントの一覧を得る
   def get_font_list
     @tmp_widget ||= Gtk::VBox.new
-    @tmp_widget.pango_context.list_families.map { |f| f.name }
+    @tmp_widget.pango_context.families.map { |f| f.name }
   end
 
 


### PR DESCRIPTION
`list_families` が `method_missing` となってmikutterが落ちていた問題を修正